### PR TITLE
Arethusa wrapper and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,114 @@ or
 
 ### Setup
 
+Running the Arethusa widget requires serving some static JavaScript and CSS files.
+The easiest way to do this is to link the files from `node_modules` to a directory in your application
+that serves static files:
+
+```
+cd path/to/static/files
+ln -s path/to/node_modules/arethusa-widget/dist/arethusa ./arethusa
+```
+
+In the `<head>` of the HTML file on the page that will contain Arethusa
+(or for a single page app, the public HTML page) add the following:
+
+```
+<script type="text/javascript" src="/public/url/arethusa/arethusa.packages.min.js"></script>
+<script type="text/javascript" src="/public/url/arethusa/arethusa.min.js"></script>
+<script type="text/javascript" src="/public/url/arethusa/arethusa.widget.loader.js"></script>
+<script type="text/javascript">
+  window.i18npath = "/public/url/arethusa/i18n/";
+  window.dagred3path = "vendor/dagre-d3/dagre-d3.min.js";
+</script>
+
+<link rel="stylesheet" type="text/css" href="/public/url/arethusa/dist/arethusa.min.css">
+<link rel="stylesheet" type="text/css" href="/public/url/arethusa/css/colorpicker.css">
+<link rel="stylesheet" type="text/css" href="/public/url/arethusa/css/font-awesome.min.css">
+<link rel="stylesheet" type="text/css" href="/public/url/arethusa/css/foundation-icons.css">
+<link rel="stylesheet" type="text/css" href="/public/url/arethusa/css/widget.css">
+```
+
+The `/public/url` is the base path of the page.
+For most applications you will probably want to change `/public/url` to `/`.
+If embedding in a React app, change `/public/url` to `%PUBLIC_URL%`.
+
 ### Usage
+
+In the JavaScript file where you would like to use Arethusa, import the `ArethusaWrapper`.
+The `ArethusaWrapper` requires an `elementId`,
+which is the `id` of the HTML element that will hold the treebank,
+a `remoteUrl`, which is the equivalent of `/public/url/arethusa` mentioned above,
+and a `doc` which is the URL of a treebank XML file.
+
+Rendering Arethusa requires a configuration. Two ready-to-go configs are provided:
+[defaultConfig](https://perseids-tools.github.io/arethusa-widget/)
+and
+[sidepanelConfig](https://perseids-tools.github.io/arethusa-widget/sidepanel).
+You will also need to provide a sentence and (optionally)
+a list of words to select.
+
+```javascript
+import { ArethusaWrapper, defaultConfig, sidepanelConfig } from 'arethusa-widget';
+
+const wrapper = new ArethusaWrapper({
+  elementId: 'treebank_container', // `id` of the HTML element containing the widget
+  remoteUrl: `/arethusa`, // the `/public/url/arethusa`; for React it would be `process.env.PUBLIC_URL + '/arethusa'`
+  doc: 'https://www.example.com/treebanks/some_treebank.xml', // URL of the treebank
+});
+
+wrapper.render({
+  chunk: '1', // sentence of the treebank to display
+  config: defaultConfig, // this can be `defaultConfig`, `sidepanelConfig`, or a custom configuration object
+  words: [1], // (optional) words to highlight; `1` highlights the first word, `2` the second word, etc.
+});
+```
+
+The HTML of the page should contain a `<div>` with class `__artsa` which should itself
+contain a `<div>`. The `id` of this second `<div>` should match the `elementId` argument passed
+to `new ArethusaWrapper()`.
+
+```html
+<div class="__artsa">
+  <div id="treebank_container" />
+</div>
+```
+
+The following functions can be used with the instantiated wrapper once it has been rendered: 
+
+```javascript
+// Go to another sentence and/or highlight other words
+wrapper.gotoSentence({
+  chunk: '2', // sentence of the treebank to display
+  words: [2,3], // (optional) words to highlight; `1` highlights the first word, `2` the second word, etc.
+});
+
+// Return the subdoc (string) of the current sentence
+wrapper.getSubdoc();
+
+// Return the morphology (object) of a particular sentence and word
+// See https://github.com/alpheios-project/arethusa/blob/widget/app/js/arethusa.core/services/api.js#L59
+wrapper.getMorph({
+  chunk: '4', // sentence of the treebank to display
+  wordId, // a word to select; `1` highlights the first word, `2` the second word, etc.
+});
+
+// Refresh the Arethusa view
+wrapper.refreshView();
+
+// Given a chunk, word, prefix (optional), and suffix (optional), moves to the
+// specified sentence and returns a list of matching words
+// See https://github.com/alpheios-project/arethusa/blob/widget/app/js/arethusa.core/services/api.js#L121
+wrapper.findWord({
+  word,
+  prefix,
+  suffix,
+});
+```
+
+(This package is designed to be used with ES6 modules and Webpack.
+If you do not have that set up for your project you will need to replace the `import`s
+with the equivalent `require`s.)
 
 ## Development
 

--- a/src/ArethusaConfig.js
+++ b/src/ArethusaConfig.js
@@ -3,7 +3,7 @@ const defaultConfig = {
     debug: false,
     showKeys: false,
     chunkParam: 'chunk',
-    auxConfPath: `${process.env.PUBLIC_URL}/arethusa/configs`,
+    auxConfPath: './configs',
     retrievers: {
       TreebankRetriever: {
         resource: 'Gardener',
@@ -34,7 +34,7 @@ const defaultConfig = {
   navbar: false,
   resources: {
     Gardener: {
-      route: `${process.env.PUBLIC_URL}/xml/:doc`,
+      route: ':doc',
       params: [
         'doc',
       ],

--- a/src/ArethusaWrapper.js
+++ b/src/ArethusaWrapper.js
@@ -10,36 +10,38 @@ const wordsDiffer = (a, b) => {
 };
 
 class ArethusaWrapper {
-  constructor() {
+  constructor({ elementId, remoteUrl, doc }) {
+    this.elementId = elementId;
+    this.remoteUrl = remoteUrl;
+    this.doc = doc
     this.render = this.render.bind(this);
   }
 
-  render({ doc, chunk, remoteUrl, elementId, config, w }) {
+  render({ chunk, config, words }) {
     const { Arethusa, $ } = window;
 
     if (this.widget) {
-      if (this.doc === doc && (this.chunk !== chunk || wordsDiffer(this.w, w))) {
-        this.gotoSentence(chunk, w);
+      if (this.chunk !== chunk || wordsDiffer(this.words, words)) {
+        this.gotoSentence(chunk, words);
         removeToastContainer($);
       }
     } else {
       this.widget = new Arethusa();
 
       this.widget
-        .on(elementId)
-        .from(remoteUrl)
+        .on(this.elementId)
+        .from(this.remoteUrl)
         .with(config)
-        .start({ doc, chunk, w });
+        .start({ doc: this.doc, chunk, w: words });
 
       this.api = this.widget.api();
     }
 
-    this.doc = doc;
     this.chunk = chunk;
-    this.w = w;
+    this.words = words;
   }
 
-  gotoSentence(chunk, words) {
+  gotoSentence({ chunk, words }) {
     return this.api.gotoSentence(chunk, words);
   }
 
@@ -47,16 +49,16 @@ class ArethusaWrapper {
     return this.api.getSubdoc();
   }
 
-  getMorph(sentenceId, wordId) {
-    return this.api.getMorph(sentenceId, wordId);
+  getMorph({ chunk, words }) {
+    return this.api.getMorph(chunk, wordId);
   }
 
   refreshView() {
     return this.api.refreshView();
   }
 
-  findWord(sentenceId, word, prefix, suffix) {
-    return this.api.findWord(sentenceId, word, prefix, suffix);
+  findWord({ chunk, word, prefix, suffix }) {
+    return this.api.findWord(chunk, word, prefix, suffix);
   }
 }
 

--- a/src/demo/index.js
+++ b/src/demo/index.js
@@ -2,7 +2,7 @@ import {
   defaultConfig,
   sidepanelConfig,
   ArethusaWrapper,
-} from '../../dist';
+} from '..';
 
 const wrapper = new ArethusaWrapper({
   elementId: 'treebank_container',


### PR DESCRIPTION
The basic setup of this repository is to use Git submodules for Arethusa and Arethusa Configs and then to build basically the `public/arethusa` directory in [Treebank Template](https://github.com/perseids-publications/treebank-template/tree/master/public/arethusa).

This PR adds the [Arethusa Wrapper](https://github.com/perseids-publications/treebank-template/blob/master/src/components/ArethusaWrapper/ArethusaWrapper.js) and a README explaining how it should be used.